### PR TITLE
Cleanup compatibilities for Python 2

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import unicode_literals, absolute_import
-
 import sys
 import os
 

--- a/docs/test.rst
+++ b/docs/test.rst
@@ -7,7 +7,7 @@ or to try a live TinyMCE 4 editor widget. The test project can also serve as a b
 
 To use the test project, first you need to install the necessary dependencies::
 
-  $ pip install -r test_requirements.txt
+  $ pip install -r requirements.txt
 
 Then you need to create the test database::
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 pyenchant
-mock
 django-filebrowser-no-grappelli
 Pillow
 Sphinx

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,2 @@
--r requirements.txt
 bumpversion
 tox

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,3 +1,3 @@
--r requirements.txt
 codecov
+tox
 tox-travis

--- a/test_tinymce/admin.py
+++ b/test_tinymce/admin.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
 from django.contrib import admin
+
 from .models import TestModel
 
 admin.site.register(TestModel)

--- a/test_tinymce/models.py
+++ b/test_tinymce/models.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from django.db import models
 from tinymce import HTMLField
 

--- a/test_tinymce/settings.py
+++ b/test_tinymce/settings.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 """
 Django settings for test_tinymce project.
 

--- a/test_tinymce/tests.py
+++ b/test_tinymce/tests.py
@@ -1,5 +1,3 @@
-# coding: utf-8
-
 import json
 
 from django.contrib.auth.models import User

--- a/test_tinymce/tests.py
+++ b/test_tinymce/tests.py
@@ -1,13 +1,9 @@
 import json
+from unittest import mock
 
 from django.contrib.auth.models import User
-from django.test import TestCase, Client
+from django.test import Client, TestCase
 from django.urls import reverse
-
-try:
-    from unittest import mock
-except ImportError:
-    import mock
 
 
 class RenderTinyMCEWidgetTestCase(TestCase):

--- a/test_tinymce/urls.py
+++ b/test_tinymce/urls.py
@@ -14,14 +14,13 @@ Including another URLconf
     2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
 """
 
-from __future__ import absolute_import
-from django.conf.urls import url, include
-from django.contrib import admin
-from django.conf.urls.static import static
 from django.conf import settings
+from django.conf.urls import include, url
+from django.conf.urls.static import static
+from django.contrib import admin
 from filebrowser.sites import site
-from .views import TestCreateView
 
+from .views import TestCreateView
 
 urlpatterns = [
     url(r'^tinymce/', include('tinymce.urls')),

--- a/test_tinymce/views.py
+++ b/test_tinymce/views.py
@@ -1,5 +1,5 @@
-from __future__ import absolute_import
 from django.views.generic import CreateView
+
 from .models import TestModel
 
 

--- a/tinymce/__init__.py
+++ b/tinymce/__init__.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 # License: MIT, see LICENSE.txt
 """
 django-tinymce4-lite
@@ -10,7 +9,6 @@ for Django forms and models.
 .. _TinyMCE 4: https://www.tinymce.com/
 """
 
-from __future__ import absolute_import, unicode_literals
 from .models import HTMLField
 from .widgets import TinyMCE, AdminTinyMCE
 

--- a/tinymce/models.py
+++ b/tinymce/models.py
@@ -1,11 +1,7 @@
-# coding: utf-8
-# Copyright (c) 2008 Joost Cassee, 2016 Roman Miroshnychenko
-# Licensed under the terms of the MIT License (see LICENSE.txt)
-
-from __future__ import absolute_import
-from django.db import models
 from django.contrib.admin.widgets import AdminTextareaWidget
-from tinymce.widgets import TinyMCE, AdminTinyMCE
+from django.db import models
+
+from .widgets import AdminTinyMCE, TinyMCE
 
 __all__ = ['HTMLField']
 

--- a/tinymce/settings.py
+++ b/tinymce/settings.py
@@ -1,8 +1,5 @@
-# coding: utf-8
-# License: MIT, see LICENSE.txt
 """The django-tinymce4-lite configuration options"""
 
-from __future__ import absolute_import, unicode_literals
 from django.conf import settings
 
 DEFAULT = {

--- a/tinymce/urls.py
+++ b/tinymce/urls.py
@@ -1,7 +1,6 @@
-# coding: utf-8
-
 from django.conf.urls import url
-from tinymce.views import spell_check, filebrowser, css
+
+from .views import css, filebrowser, spell_check
 
 urlpatterns = [
     url(r'^spellchecker/$', spell_check, name='tinymce-spellchecker'),

--- a/tinymce/views.py
+++ b/tinymce/views.py
@@ -1,11 +1,6 @@
-# coding: utf-8
-# License: MIT, see LICENSE.txt
 """
 django-tinymce4-lite views
 """
-
-from __future__ import absolute_import
-
 import json
 import logging
 

--- a/tinymce/views.py
+++ b/tinymce/views.py
@@ -1,6 +1,3 @@
-"""
-django-tinymce4-lite views
-"""
 import json
 import logging
 

--- a/tinymce/widgets.py
+++ b/tinymce/widgets.py
@@ -1,20 +1,15 @@
-# coding: utf-8
-# License: MIT, see LICENSE.txt
 """
 TinyMCE 4 forms widget
 
 This TinyMCE widget was copied and extended from this code by John D'Agostino:
 http://code.djangoproject.com/wiki/CustomWidgetsTinyMCE
 """
-
-from __future__ import unicode_literals, absolute_import
-
 import json
 import logging
 
 from django.conf import settings
 from django.contrib.admin import widgets as admin_widgets
-from django.forms import Textarea, Media
+from django.forms import Media, Textarea
 from django.forms.utils import flatatt
 from django.template.loader import render_to_string
 from django.urls import reverse
@@ -23,7 +18,7 @@ from django.utils.html import escape
 from django.utils.safestring import mark_safe
 from django.utils.translation import get_language, get_language_bidi
 
-import tinymce.settings as mce_settings
+from . import settings as mce_settings
 
 __all__ = ['TinyMCE', 'render_tinymce_init_js']
 


### PR DESCRIPTION
- Remove future imports
- Remove `coding: utf-8` as it's the default under Python 3
- Remove use of mock library