### PR TITLE
Drop support for Python 3.5 and Django <2.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,21 +47,6 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-          - python: 3.5
-            django: ">=1.11,<2.0"
-          - python: 3.5
-            django: ">=2.0,<2.1"
-          - python: 3.5
-            django: ">=2.1,<2.2"
-          - python: 3.5
-            django: ">=2.2,<3.0"
-
-          - python: 3.6
-            django: ">=1.11,<2.0"
-          - python: 3.6
-            django: ">=2.0,<2.1"
-          - python: 3.6
-            django: ">=2.1,<2.2"
           - python: 3.6
             django: ">=2.2,<3.0"
           - python: 3.6
@@ -69,12 +54,6 @@ jobs:
           - python: 3.6
             django: ">=3.1,<3.2"
 
-          - python: 3.7
-            django: ">=1.11,<2.0"
-          - python: 3.7
-            django: ">=2.0,<2.1"
-          - python: 3.7
-            django: ">=2.1,<2.2"
           - python: 3.7
             django: ">=2.2,<3.0"
           - python: 3.7

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ This version **does not** include any static files, it's using the TinyMCE from 
 
 ## Compatibility
 
--   **Python**: 3.5-3.8
--   **Django**: 1.11-3.1
+-   **Python**: 3.6-3.8
+-   **Django**: 2.2-3.1
 
 ## Quick Start
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,8 +6,8 @@ The main difference with the original fork is that it **does not** include any s
 
 ## Compatibility
 
--   **Python**: 3.5-3.8
--   **Django**: 1.11-3.1
+-   **Python**: 3.6-3.8
+-   **Django**: 2.2-3.1
 
 ## License
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,14 +18,10 @@ classifiers =
 	Operating System :: OS Independent
 	Programming Language :: Python
 	Programming Language :: Python :: 3
-	Programming Language :: Python :: 3.5
 	Programming Language :: Python :: 3.6
 	Programming Language :: Python :: 3.7
 	Programming Language :: Python :: 3.8
 	Framework :: Django
-	Framework :: Django :: 1.11
-	Framework :: Django :: 2.0
-	Framework :: Django :: 2.1
 	Framework :: Django :: 2.2
 	Framework :: Django :: 3.0
 	Framework :: Django :: 3.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,28 +1,16 @@
 [tox]
 envlist =
-    py{34,35,36,37}-dj{111,20,21,master}
+    py{36,37,38}-dj{22,30,31}
     lint,docs
-
-[travis:env]
-DJANGO =
-    1.10: dj110
-    1.11: dj111
-    2.0: dj20
-    2.1: dj21
-    master: djmaster
 
 
 [testenv]
 commands = coverage run manage.py test test_tinymce
 deps =
     -rrequirements.txt
-    dj110: Django>=1.10,<1.11
-    dj111: Django>=1.11,<2.0
-    dj20: Django>=2.0,<2.1
-    dj21: Django>=2.1,<2.2
     dj22: Django>=2.1,<3.0
     dj30: Django>=3.0,<3.1
-    djmaster: https://github.com/django/django/archive/master.tar.gz
+    dj31: Django>=3.1,<3.2
 
 [testenv:lint]
 basepython = python3.6


### PR DESCRIPTION
BREAKING: Drop support for Python 3.5 and Django <2.2