### PR TITLE
feat: drop support for Python 3.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,6 @@ jobs:
       fail-fast: false
       matrix:
         versions:
-          - python: "3.7"
-            django: "2.2"
-          - python: "3.7"
-            django: "3.0"
-          - python: "3.7"
-            django: "3.1"
-          - python: "3.7"
-            django: "3.2"
-
           - python: "3.8"
             django: "2.2"
           - python: "3.8"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     rev: v3.7.0
     hooks:
       - id: pyupgrade
-        args: [--py37-plus]
+        args: [--py38-plus]
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
     hooks:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This version **does not** include any static files, it's using the TinyMCE from 
 
 ## Compatibility
 
-- **Python**: 3.7-3.10
+- **Python**: 3.8-3.10
 - **Django**: 2.2-4.1
 
 ## Quick Start

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ The main difference with the original fork is that it **does not** include any s
 
 ## Compatibility
 
-- **Python**: 3.7-3.10
+- **Python**: 3.8-3.10
 - **Django**: 2.2-4.1
 
 ## License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = "^3.8"
 Django = ">=2.2,<4.2"
 pyenchant = { version = "^3.1", optional = true }
 


### PR DESCRIPTION
BREAKING CHANGE: Drop support for Python 3.7 as it reached EOL on June 27, 2023. More infos: https://devguide.python.org/versions/

Committed via https://github.com/asottile/all-repos